### PR TITLE
fix: run gh-pages ci pipeline in main branch

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -2,7 +2,7 @@ name: ci
 on:
   push:
     branches:
-      - dev
+      - main
 jobs:
 
   deploy:


### PR DESCRIPTION
In my initial PR #21 , I had incorrectly set the GitHub actions to run only for pushes to the dev branch instead of the main branch.
Hence, I ran the GitHub pages CI pipeline in the main branch instead of dev branch.